### PR TITLE
Upgrade pgsql binaries to v13

### DIFF
--- a/Postgres.Native/Postgres.Native/Postgres.Native.csproj
+++ b/Postgres.Native/Postgres.Native/Postgres.Native.csproj
@@ -12,11 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="postgresql-11.5-1-windows-x64-binaries.zip" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="postgresql-11.5-1-windows-x64-binaries.zip" />
+    <None Remove="postgresql-13.4-1-windows-x64-binaries.zip" />
+    <EmbeddedResource Include="postgresql-13.4-1-windows-x64-binaries.zip" />
   </ItemGroup>
 
 </Project>

--- a/Postgres.Native/Postgres.Native/PostgresBinariesExtractor.cs
+++ b/Postgres.Native/Postgres.Native/PostgresBinariesExtractor.cs
@@ -12,7 +12,7 @@ namespace Postgres.Native
         {
             var pgAssembly = Assembly.GetExecutingAssembly();
 
-            var pgStream = pgAssembly.GetManifestResourceStream("Postgres.Native.postgresql-11.5-1-windows-x64-binaries.zip");
+            var pgStream = pgAssembly.GetManifestResourceStream("Postgres.Native.postgresql-13.4-1-windows-x64-binaries.zip");
 
             if (pgStream == null)
             {

--- a/Postgres.Native/global.json
+++ b/Postgres.Native/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "5.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Updated pgsql binaries to v13. Added as embedded resource.
Remove unnecessary dependencies from zip archive to keep size down.
Added sdk support hints for rider.